### PR TITLE
backwards compatibility for Android 4.4

### DIFF
--- a/likebutton/src/main/java/com/like/LikeButton.java
+++ b/likebutton/src/main/java/com/like/LikeButton.java
@@ -11,6 +11,7 @@ import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.annotation.DrawableRes;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.content.res.AppCompatResources;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
@@ -142,7 +143,7 @@ public class LikeButton extends FrameLayout implements View.OnClickListener {
     private Drawable getDrawableFromResource(TypedArray array, int styleableIndexId) {
         int id = array.getResourceId(styleableIndexId, -1);
 
-        return (-1 != id) ? ContextCompat.getDrawable(getContext(), id) : null;
+        return (-1 != id) ? AppCompatResources.getDrawable(getContext(), id) : null;
     }
 
     /**


### PR DESCRIPTION
It's crash on Android 4.4 (Xiaomi Redmi).

```
        <com.like.LikeButton
            android:id="@+id/vector_android_button"
            android:layout_width="wrap_content"
            android:layout_height="wrap_content"
            app:circle_end_color="@android:color/holo_green_dark"
            app:circle_start_color="@android:color/holo_green_dark"
            app:dots_primary_color="@android:color/holo_green_dark"
            app:dots_secondary_color="@android:color/holo_green_light"
            app:icon_size="22dp"
            app:like_drawable="@drawable/ic_android_green_500_24dp"
            app:unlike_drawable="@drawable/ic_android_grey_500_24dp" />
```